### PR TITLE
fix: moralis webhook onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,39 @@
 # Server
-SERVER_PORT=add_your_port_here
+SERVER_PORT=8000
 
 # Database
-DB_URL=add_your_database_url_here
+DB_URL=postgresql://postgres:postgres@localhost:5432/locker_dev
 
-# Clerk
-CLERK_SECRET_KEY=add_your_clerk_secret_key_here
-CLERK_PUBLISHABLE_KEY=add_your_clerk_publishable_key_here
+# # Clerk
+CLERK_SECRET_KEY=
+CLERK_PUBLISHABLE_KEY=
+
+RPCs
+ARBITRUM_RPC=
+ETHEREUM_RPC=
+POLYGON_RPC=
+OPTIMISM_RPC=
+BASE_RPC=
+AVALANCHE_RPC=
+
+SEPOLIA_RPC=
+BASE_SEPOLIA_RPC=
+ARBITRUM_SEPOLIA_RPC=
+OPTIMISM_SEPOLIA_RPC=
+AVALANCHE_FUJI_RPC=
+POLYGON_MUMBAI_RPC=
+
+# Moralis
+MORALIS_STREAM_ID=
+MORALIS_API_KEY=
+MORALIS_STREAM_SECRET=
+
+# Locker
+LOCKER_BASE_URL=http://localhost:3000
+
+# Resend
+RESEND_API_KEY=
+
+# Encrption
+ENCRYPTION_ALGORITHM=aes-256-cbc
+ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ yarn migrate
 yarn migration:generate
 yarn migrate
 ```
+
+### Moralis Stream ID
+
+[Moralis Streams](https://docs.moralis.io/streams-api/evm) are used for getting realtime updates about deposits into Lockers. A single stream is used for processing updates across all chains and addresses. That stream must be created manually and added to your `.env` as `MORALIS_STREAM_ID`. To generate the stream id:
+
+1. Set `LOCKER_BASE_URL` in `.env`.
+1. Update `chains`, `description`, and `tag` in `gen-moralis-stream.ts`.
+1. Run `yarn stream:create`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"migrate": "pnpm tsx ./drizzle/migrate.ts",
 		"migration:generate": "pnpm drizzle-kit generate:pg",
 		"prepare": "husky",
+		"stream:create": "tsx scripts/gen-moralis-stream.ts",
 		"test": "jest --coverage",
 		"test:match": "jest --verbose"
 	},

--- a/scripts/gen-moralis-stream.ts
+++ b/scripts/gen-moralis-stream.ts
@@ -1,0 +1,114 @@
+// We use Moralis for listening to on-chain events
+// One stream is created for all addresses we want to
+import dotenv from "dotenv";
+import Moralis from "moralis";
+
+dotenv.config();
+
+// Subset of Moralis + ZeroDev supported chains
+// https://docs.moralis.io/supported-chains
+// https://docs.zerodev.app/sdk/faqs/chains#supported-networks
+const chains = [
+	// sepolia - 11155111
+	"0xaa36a7",
+
+	// arbitrum sepolia - 421614
+	"0x66eee",
+	// arbitrum one - 42161
+	"0xa4b1",
+
+	// avalanche fuji - 43113
+	"0xa869",
+	// avalanche mainnet - 43114
+	"0xa86a",
+
+	// base sepolia - 84532
+	"0x14a34",
+	// base mainnet - 8453
+	"0x2105",
+
+	// linea mainnet - 59144
+	// "0xe708",
+
+	// ZeroDev is on linea goerli currently but moralis is on sepolia, so we have to use mainnet
+	// linea sepolia - 59141
+	// "0xe705",
+
+	// gnosis mainnet - 100
+	// "0x64",
+
+	// optimism sepolia - 11155420
+	"0xaa37dc",
+	// optimism mainnet - 10
+	"0xa",
+
+	// polygon amoy - 80002
+	"0x13882",
+	// polygon mainnet - 137
+	"0x89",
+];
+
+const tag = "staging";
+const description = `Transactions ${tag}`;
+
+const ERC20TransferEventABI = [
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				name: "from",
+				type: "address",
+			},
+			{
+				indexed: true,
+				name: "to",
+				type: "address",
+			},
+			{
+				indexed: false,
+				name: "value",
+				type: "uint256",
+			},
+		],
+		name: "Transfer",
+		type: "event",
+	},
+];
+
+const createStream = async () => {
+	console.log("Creating Moralis stream...");
+	const host = process.env.LOCKER_BASE_URL;
+
+	// Omit leading slash
+	const txUpdatePath = `integrations/moralis/webhooks/transactions`;
+	const webhookUrl = `${host}/${txUpdatePath}`;
+	console.log("WebhookUrl: ", webhookUrl);
+
+	const topic = "Transfer(address,address,uint256)";
+
+	const response = await Moralis.Streams.add({
+		webhookUrl,
+		description,
+		tag,
+		chains,
+		includeNativeTxs: true,
+		abi: ERC20TransferEventABI,
+		includeContractLogs: true,
+		topic0: [topic],
+	});
+
+	console.log(JSON.stringify(response.toJSON(), null, 2));
+	console.log("Stream successfully created");
+	return response.toJSON().id;
+};
+
+const doCreateStream = async () => {
+	await Moralis.start({
+		apiKey: process.env.MORALIS_API_KEY,
+	});
+
+	await createStream();
+};
+
+doCreateStream();

--- a/src/infrastructure/README.md
+++ b/src/infrastructure/README.md
@@ -1,3 +1,3 @@
 # Periphery Directory
 
-This directory contains peripheral infrasctructure that serves the needs of core business logic.
+This directory contains peripheral infrastructure that serves the needs of core business logic.

--- a/src/infrastructure/web/endpoints/integrations/moralis.ts
+++ b/src/infrastructure/web/endpoints/integrations/moralis.ts
@@ -34,6 +34,16 @@ moralisRouter.post(
 				res.status(400).send({ error: error.message });
 				return;
 			}
+			console.error(
+				"Got an unknown error in the webhook verification.",
+				error
+			);
+
+			res.status(500).send({
+				error: "An unexpected error occurred.",
+			});
+
+			return;
 		}
 
 		// 2. store tx data in database


### PR DESCRIPTION
When setting up a new webhook, Moralis sends a test message. For some reason that test message is failing the authenticity check. This prevents the webhook from registering successfully. We are currently implementing a workaround that returns 200 immediately if txs and erc20Transfers are empty.

This commit also includes scripts for registering a new webhook with Moralis.