### PR TITLE
fix: check balances on all chains

### DIFF
--- a/src/infrastructure/web/endpoints/public/tokenTxs.ts
+++ b/src/infrastructure/web/endpoints/public/tokenTxs.ts
@@ -12,7 +12,6 @@ import {
 	logger,
 	stream,
 } from "../../../../dependencies";
-import { ETokenTxLockerDirection } from "../../../../usecases/schemas/tokenTxs";
 
 const tokenTxsRouter = express.Router();
 tokenTxsRouter.use(express.json());
@@ -67,17 +66,10 @@ tokenTxsRouter.get(
 
 		const { address: lockerAddress } = locker;
 
-		const tokenTxsRepo = await getTokenTxsRepo();
-		const txs = await tokenTxsRepo.retrieveMany({
-			lockerId: parseInt(req.params.lockerId, 10),
-			lockerDirection: ETokenTxLockerDirection.IN,
-		});
-
 		const indexerClient = await getIndexerClient();
 
 		const data = await indexerClient.getLockerTokenBalances({
 			lockerAddress,
-			txs,
 		});
 		res.status(200).json({ data });
 	}

--- a/src/usecases/interfaces/clients/indexer.ts
+++ b/src/usecases/interfaces/clients/indexer.ts
@@ -1,7 +1,6 @@
 import { IWebhook } from "@moralisweb3/streams-typings";
 
 import { ILockerTokenBalance } from "../../schemas/lockers";
-import { TokenTxInDb } from "../../schemas/tokenTxs";
 
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
@@ -13,10 +12,8 @@ interface IIndexerClient {
 	// Given a list of transactions, return all token balances for each chain-contract combination.
 	getLockerTokenBalances({
 		lockerAddress,
-		txs,
 	}: {
 		lockerAddress: `0x${string}`;
-		txs: TokenTxInDb[];
 	}): Promise<ILockerTokenBalance[]>;
 }
 

--- a/tests/test_infrastructure/test_clients/TestMoralisClient.test.ts
+++ b/tests/test_infrastructure/test_clients/TestMoralisClient.test.ts
@@ -9,6 +9,15 @@ import {
 } from "../../../src/usecases/schemas/tokenTxs";
 
 describe("MoralisClient", () => {
+	it.skip("getLockerTokenBalances", async () => {
+		const moralisClient = new MoralisClient();
+		const balances = await moralisClient.getLockerTokenBalances({
+			lockerAddress: "0x3abb17dd306cba6d4ccad0bbd880d0cbd0a2cdaa",
+		});
+
+		expect(balances).toMatchObject([]);
+	});
+
 	it.skip("groupTxsByChainAndToken", async () => {
 		const lockerAddress = "0xAF115955b028c145cE3A7367B25A274723C5104B";
 		const moralisClient = new MoralisClient();


### PR DESCRIPTION
Not just on the ones we have transactions for. Those transactions could have happened before locker DB knew about balances.