### PR TITLE
fix: don't fire db update if nothing changed

### DIFF
--- a/__tests__/test_infrastructure/db/TokenTxsRepo.test.ts
+++ b/__tests__/test_infrastructure/db/TokenTxsRepo.test.ts
@@ -49,6 +49,56 @@ describe.skip("TokenTxsRepo", () => {
 			lockerDirection: ETokenTxLockerDirection.IN,
 			automationsState: ETokenTxAutomationsState.NOT_STARTED,
 		};
+		const updatedTx = await tokenTxDb.create(unconfirmedTx);
+		console.log("updatedTx");
+		console.log(updatedTx);
+
+		// check that the tx is still confirmed
+		expect(updatedTx).toBeUndefined();
+		const tx = await tokenTxDb.retrieve({ id });
+		expect(tx?.isConfirmed).toBe(true);
+	});
+
+	it("create does override pending", async () => {
+		const txHash = `0x${genRanHex(64)}` as `0x${string}`;
+		console.log(txHash);
+		const confirmedTx: TokenTxRepoAdapter = {
+			amount: BigInt(1000),
+			txHash,
+			chainId: 11155111,
+			lockerId: 1,
+			toAddress: "0xTOADDRESS",
+			fromAddress: "0xaf115955b028c145ce3a7367b25a274723c5104b",
+			isConfirmed: false,
+			tokenSymbol: "USDC",
+			tokenDecimals: 6,
+			contractAddress: "0x1c7d4b196cb07b01d743fbc6116a902379c7238",
+			lockerDirection: ETokenTxLockerDirection.IN,
+			automationsState: ETokenTxAutomationsState.NOT_STARTED,
+		};
+
+		// first create tx as confirmed
+		const db = getOrCreateDatabase(logger);
+		const tokenTxDb = new TokenTxsRepo(db);
+		const { id, isConfirmed } = await tokenTxDb.create(confirmedTx);
+		expect(id).toBeDefined();
+		expect(isConfirmed).toBe(false);
+
+		// then process unconfirmed
+		const unconfirmedTx: TokenTxRepoAdapter = {
+			amount: BigInt(1000),
+			txHash,
+			chainId: 11155111,
+			lockerId: 1,
+			toAddress: "0xTOADDRESS",
+			fromAddress: "0xaf115955b028c145ce3a7367b25a274723c5104b",
+			isConfirmed: true,
+			tokenSymbol: "USDC",
+			tokenDecimals: 6,
+			contractAddress: "0x1c7d4b196cb07b01d743fbc6116a902379c7238",
+			lockerDirection: ETokenTxLockerDirection.IN,
+			automationsState: ETokenTxAutomationsState.NOT_STARTED,
+		};
 		const { id: updatedId } = await tokenTxDb.create(unconfirmedTx);
 
 		// check that the tx is still confirmed

--- a/src/infrastructure/db/repos/tokenTxs.ts
+++ b/src/infrastructure/db/repos/tokenTxs.ts
@@ -37,12 +37,7 @@ export default class TokenTxsRepo implements ITokenTxsRepo {
 					target: [tokenTxs.chainId, tokenTxs.txHash],
 					set: {
 						automationsState: tokenTx.automationsState,
-						isConfirmed: sql.raw(`
-							CASE
-								WHEN token_transactions.${tokenTxs.isConfirmed.name} IS TRUE THEN TRUE
-								ELSE excluded.${tokenTxs.isConfirmed.name}
-							END
-						`),
+						isConfirmed: tokenTx.isConfirmed,
 						triggeredByTokenTxId: sql.raw(`
 							CASE
 								WHEN token_transactions.${tokenTxs.triggeredByTokenTxId.name} IS NOT NULL THEN token_transactions.${tokenTxs.triggeredByTokenTxId.name}
@@ -50,6 +45,11 @@ export default class TokenTxsRepo implements ITokenTxsRepo {
 							END
 						`),
 					},
+					// Only update if the tx is not confirmed to prevent regressions
+					// We do this to prevent two DB events from firing and potentially triggering multiple automations due to race conditions
+					setWhere: sql.raw(
+						`token_transactions.${tokenTxs.isConfirmed.name} IS FALSE`
+					),
 				})
 				.returning();
 

--- a/src/infrastructure/web/endpoints/integrations/moralis.ts
+++ b/src/infrastructure/web/endpoints/integrations/moralis.ts
@@ -178,7 +178,13 @@ moralisRouter.post(
 				);
 
 				try {
-					await tokenTxsRepo.create(tokenTx);
+					const createdTx = await tokenTxsRepo.create(tokenTx);
+					// This can happen if the tx is already confirmed and we try to upsert it as unconfirmed
+					if (!createdTx) {
+						throw new Error(
+							"Unable to create token tx, maybe it was already confirmed before this update?"
+						);
+					}
 				} catch (error) {
 					if (error instanceof DuplicateRecordError) {
 						res.status(409).send({
@@ -212,6 +218,7 @@ moralisRouter.post(
 		} catch (error) {
 			// Swallow exceptions to prevent unexpected retry behavior from Moralis
 			logger.error("Unable to process message from moralis", moralisBody);
+			logger.error(error);
 		}
 
 		// Saving the txs to the DB triggers webhooks from Supabase


### PR DESCRIPTION
Problem: Arbitrum events for pending and confirm from Moralis are sent at nearly identical times. We handle these updates concurrently, leading to unpredictable beharvior. There are a few things going on here:


## 1. Upsert logic
We have [granular control](https://github.com/chainrule-labs/locker-api/blob/41ca6fee46dd7e2339f2328b7e1796f082fc9e98/src/infrastructure/db/repos/tokenTxs.ts#L39) of upsert logic. Yesterday, I made it so a PENDING state wouldn't override a CONFIRMED state. But it was still firing a DB update. This caused a race condition between processing the two DB updates and led to two automations happening.

This PR prevents tokenTxs.create from doing anything to the DB if it is not actually updating the `isConfirmed` state.


## 2. Nearly impossible to avoid race conditions when handling state changes concurrently

High frequency systems typically process event updates synchronously. There may be async pipes that push events onto the queue/broker/actor, but ultimately the business logic should process these updates one at a time. Parallelization can be achieved by sharding the events across domains (eg Base events can be processes in parallel with Arbitrum).

IMHO, the easiest way to achieve this is to add a message broker in between the DB and the backend. This way, we can be sure the backend only processes a single event at a time. I'd vote for Google PubSub. I've also used Kafka a lot, it's just a pain to manage all that infrastructure.

This work is not included in the PR.

